### PR TITLE
Minor setup.py cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Basic Functionality that are covered :
 To install the library with PIP use:
 
 ```bash
-python -m pip install --upgrade git+https://github.com/xSAVIKx/adobe_analytics_api_2.0.git#egg=adobe_analytics_2
+python -m pip install --upgrade git+https://github.com/pitchmuc/adobe_analytics_api_2.0.git#egg=adobe_analytics_2
 ```
 
 ## Dependencies

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
 from setuptools import setup, find_packages
 
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
 CLASSIFIERS = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
@@ -14,6 +17,16 @@ CLASSIFIERS = [
 
 setup(
     name='adobe_analytics_2',
+    version='0.1',
+    license='GPL',
+    description='Adobe Analytics v2 API wrapper',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    author='Julien Piccini',
+    author_email='piccini.julien@gmail.com',
+    url='https://github.com/pitchmuc/adobe_analytics_api_2.0',
+    download_url='https://github.com/pitchmuc/adobe_analytics_api_2.0/archive/master.zip',
+    keywords=['adobe', 'analytics', 'API', 'python'],
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
@@ -21,6 +34,8 @@ setup(
         'jwt>=0.6.1',
         'pathlib2>=2.3.5',
         'requests>=2.22.0',
+        'PyJWT>=1.7.1'
     ],
-    classifiers=CLASSIFIERS
+    classifiers=CLASSIFIERS,
+    python_requires='>=3.5'
 )

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
     author='Julien Piccini',
     author_email='piccini.julien@gmail.com',
     url='https://github.com/pitchmuc/adobe_analytics_api_2.0',
-    download_url='https://github.com/pitchmuc/adobe_analytics_api_2.0/archive/master.zip',
     keywords=['adobe', 'analytics', 'API', 'python'],
     packages=find_packages(),
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 from setuptools import setup, find_packages
 
+from adobe_analytics_2 import __version__
+
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
@@ -17,7 +19,7 @@ CLASSIFIERS = [
 
 setup(
     name='adobe_analytics_2',
-    version='0.1',
+    version=__version__,
     license='GPL',
     description='Adobe Analytics v2 API wrapper',
     long_description=long_description,


### PR DESCRIPTION
In this PR I have added some essential fields that are actually required to perform the clean `pip` installation from the `requirements.txt`.

You can go ahead and actually publish it to Pypi using this [tutorial](https://realpython.com/pypi-publish-python-package/#a-small-python-package).