### PR TITLE
Remove duplicate JWT package

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ In order to use this API in python, you would need to have those libraries insta
 - pandas
 - requests
 - json
-- pyjwt
-- jwt 
+- PyJWT
 - pathlib
 
 ## Others Sources

--- a/adobe_analytics_2/__init__.py
+++ b/adobe_analytics_2/__init__.py
@@ -1,1 +1,1 @@
-__version__ = 0.2
+__version__ = 0.3

--- a/adobe_analytics_2/aanalytics2.py
+++ b/adobe_analytics_2/aanalytics2.py
@@ -1,6 +1,6 @@
 # Created by julien piccini
 # email : piccini.julien@gmail.com
-# version : 0.1
+# version : 0.3
 
 
 import json as _json

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas>=0.25.3
 PyJWT>=1.7.1
 pathlib2>=2.3.5
 requests>=2.22.0
+PyJWT[crypto]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-pandas>=0.25.1
+pandas>=0.25.3
 PyJWT>=1.7.1
-jwt>=0.6.1
 pathlib2>=2.3.5
 requests>=2.22.0

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'pandas>=0.25.1',
-        'jwt>=0.6.1',
+        'pandas>=0.25.3',
         'pathlib2>=2.3.5',
         'requests>=2.22.0',
         'PyJWT>=1.7.1'

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(
         'pandas>=0.25.3',
         'pathlib2>=2.3.5',
         'requests>=2.22.0',
-        'PyJWT>=1.7.1'
+        'PyJWT>=1.7.1',
+        'PyJWT[crypto]'
     ],
     classifiers=CLASSIFIERS,
     python_requires='>=3.5'


### PR DESCRIPTION
In this PR I have removed `jwt` dependency while it is an obsolete one.

Both `jwt` and `PyJWT` provides the same functionality and use the same `jwt` package for their code. Having both dependencies at the same time leads to the inconsistency that may or may not be an issue depending on personal luck. It may work on the personal PC but suddenly stops working on the server just because of the order in which the dependencies were resolved.

While we rely on the `encode` method from the `jwt` package, we should use `PyJWT` and not `jwt`.