### PR TITLE
Make sure PyJWT[crypto] is a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ In order to use this API in python, you would need to have those libraries insta
 - requests
 - json
 - PyJWT
+- PyJWT[crypto]
 - pathlib
 
 ## Others Sources

--- a/adobe_analytics_2/__init__.py
+++ b/adobe_analytics_2/__init__.py
@@ -1,1 +1,1 @@
-__version__ = 0.3
+__version__ = 0.4

--- a/adobe_analytics_2/aanalytics2.py
+++ b/adobe_analytics_2/aanalytics2.py
@@ -1,6 +1,6 @@
 # Created by julien piccini
 # email : piccini.julien@gmail.com
-# version : 0.3
+# version : 0.4
 
 
 import json as _json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pandas>=0.25.3
+PyJWT[crypto]>=1.7.1
 PyJWT>=1.7.1
 pathlib2>=2.3.5
 requests>=2.22.0
-PyJWT[crypto]

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,8 @@ setup(
         'pandas>=0.25.3',
         'pathlib2>=2.3.5',
         'requests>=2.22.0',
-        'PyJWT>=1.7.1',
-        'PyJWT[crypto]'
+        'PyJWT[crypto]>=1.7.1',
+        'PyJWT>=1.7.1'
     ],
     classifiers=CLASSIFIERS,
     python_requires='>=3.5'


### PR DESCRIPTION
While in most cases the `cryptography` library will be installed, in some restricted environments like Google App Engine or Cloud Functions it is required to state all the dependencies.

To make sure we have them all, I've added the `PyJWT[crypto]` as stated in the [docs](https://pyjwt.readthedocs.io/en/latest/installation.html#cryptographic-dependencies-optional). (we do actually use `RS256` crypto-algorithm, so, obviously, this dependency is required for us).