### PR TITLE
Add handling of columnErrors in getReport

### DIFF
--- a/adobe_analytics_2/aanalytics2.py
+++ b/adobe_analytics_2/aanalytics2.py
@@ -909,6 +909,13 @@ def getReport(
         page_nb += 1
         if verbose:
             print(f"# of requests : {page_nb}")
+    # Filter out error Columns
+    if "columnErrors" in report["columns"].keys():
+        for column_error in report["columns"]["columnErrors"]:
+            column_name = next((column["id"] for column in json_request["metricContainer"]["metrics"] if column["columnId"] == column_error["columnId"]), None)
+            if verbose:
+                print(f"Warning : not able to get column {column_name}: {column_error['errorDescription']}")
+            columns.remove(column_name)
     # return report
     df = _readData(data_list, anomaly=anomaly, cols=columns, item_id=item_id)
     if save:

--- a/adobe_analytics_2/aanalytics2.py
+++ b/adobe_analytics_2/aanalytics2.py
@@ -912,7 +912,7 @@ def getReport(
     # Filter out error Columns
     if "columnErrors" in report["columns"].keys():
         for column_error in report["columns"]["columnErrors"]:
-            column_name = next((column["id"] for column in json_request["metricContainer"]["metrics"] if column["columnId"] == column_error["columnId"]), None)
+            column_name = next((column["id"] for column in json_request["metricContainer"]["metrics"] if str(column["columnId"]) == str(column_error["columnId"])), None)
             if verbose:
                 print(f"Warning : not able to get column {column_name}: {column_error['errorDescription']}")
             columns.remove(column_name)


### PR DESCRIPTION
Before creating the resulting dataframe, the API response is checked
upon the existance of columnErrors.
Any erroneous columns are then removed from the columns list.

In case verbose is true, a warning is printed with the metric name and
error description.

This fixes pitchmuc/adobe_analytics_api_2.0#11