### PR TITLE
Don't duplicate "login" column and do not crash if AA does not return "admin" column

### DIFF
--- a/aanalytics2/aanalytics2.py
+++ b/aanalytics2/aanalytics2.py
@@ -707,9 +707,10 @@ class Analytics:
             data = data + append_data
         df_users = pd.DataFrame(data)
         if df_users.empty == False:
-            columns = ['email', 'login', 'fullName', 'firstName', 'lastName', 'admin', 'loginId', 'imsUserId', 'login',
+            columns = ['email', 'login', 'fullName', 'firstName', 'lastName', 'admin', 'loginId', 'imsUserId', 
                     'createDate', 'lastAccess', 'title', 'disabled', 'phoneNumber', 'companyid']
-            df_users = df_users[columns]
+            columns_to_keep = [col for col in columns if col in df_users.columns]
+            df_users = df_users[columns_to_keep]
             df_users['createDate'] = pd.to_datetime(df_users['createDate'])
             df_users['lastAccess'] = pd.to_datetime(df_users['lastAccess'])
         if save:


### PR DESCRIPTION
Adobe does not officially support the "admin" column (https://developer.adobe.com/analytics-apis/docs/2.0/apis/#tag/Users) and recently (unclear if temporarily only) stopped providing it in the response. Furthermore, the "login" column should not get duplicated.